### PR TITLE
Retry transient Morph Compact failures (429/5xx/network) instead of losing the whole summary

### DIFF
--- a/hooks/lib/morph.js
+++ b/hooks/lib/morph.js
@@ -2,6 +2,7 @@ import { join } from "path";
 import { homedir } from "os";
 import { readFileSync } from "fs";
 import { CompactClient } from "@morphllm/morphsdk";
+import { log } from "./state.js";
 
 const COMPACT_TIMEOUT = 60000;
 const COMPACT_PRESERVE_RECENT = parseInt(
@@ -9,6 +10,20 @@ const COMPACT_PRESERVE_RECENT = parseInt(
   10,
 );
 const COMPACT_RATIO = parseFloat(process.env.MORPH_COMPACT_RATIO || "0.3");
+
+// Retry config. Morph Compact can fail transiently — 429 rate-limit bursts, 5xx,
+// or a network/timeout blip. Before this, a single failed call lost the entire
+// summary (pre-compact.js caches an empty summary on throw), so a momentary 429
+// wiped the user's whole prior context. Retry retryable failures with exponential
+// backoff + full jitter before giving up. Set MORPH_COMPACT_MAX_RETRIES=0 to disable.
+const COMPACT_MAX_RETRIES = Math.max(
+  0,
+  parseInt(process.env.MORPH_COMPACT_MAX_RETRIES || "3", 10),
+);
+const COMPACT_RETRY_BASE_MS = Math.max(
+  0,
+  parseInt(process.env.MORPH_COMPACT_RETRY_BASE_MS || "1000", 10),
+);
 
 export const MORPH_STATE_DIR = join(homedir(), ".claude", "morph");
 const ENV_FILE = join(MORPH_STATE_DIR, ".env");
@@ -36,18 +51,61 @@ const client = new CompactClient({
   morphApiKey: loadApiKey(),
 });
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// The SDK throws `new Error("Compact API error <status>: <body>")` for any non-2xx
+// (it does NOT attach a numeric status property), and a plain network/abort Error
+// (no status) on connection or timeout failure. So we classify by parsing the
+// message: retry transient HTTP statuses and all network/timeout errors; fail fast
+// on auth/validation 4xx (401/403/400/404) where a retry can never succeed.
+function isRetryable(err) {
+  const msg = String((err && err.message) || err || "");
+  const httpMatch = msg.match(/Compact API error (\d{3})/);
+  if (httpMatch) {
+    const status = parseInt(httpMatch[1], 10);
+    return (
+      status === 408 ||
+      status === 425 ||
+      status === 429 ||
+      (status >= 500 && status <= 599)
+    );
+  }
+  // No HTTP status in the message → treat connection/timeout/abort errors as retryable.
+  return /fetch failed|network|timeout|timed out|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|socket hang up|aborted|AbortError/i.test(
+    msg,
+  );
+}
+
 export async function compact(messages) {
   if (messages.length === 0) return "Empty session - no prior context.";
 
   const lastUserMsg = messages.findLast((m) => m.role === "user");
 
-  const result = await client.compact({
-    messages,
-    query: lastUserMsg?.content,
-    compressionRatio: COMPACT_RATIO,
-    preserveRecent: COMPACT_PRESERVE_RECENT,
-    includeMarkers: true,
-  });
+  let lastErr;
+  for (let attempt = 0; attempt <= COMPACT_MAX_RETRIES; attempt++) {
+    try {
+      const result = await client.compact({
+        messages,
+        query: lastUserMsg?.content,
+        compressionRatio: COMPACT_RATIO,
+        preserveRecent: COMPACT_PRESERVE_RECENT,
+        includeMarkers: true,
+      });
+      return result.output;
+    } catch (err) {
+      lastErr = err;
+      if (attempt >= COMPACT_MAX_RETRIES || !isRetryable(err)) break;
+      // Exponential backoff with full jitter: random in [0, base * 2^attempt).
+      const ceiling = COMPACT_RETRY_BASE_MS * Math.pow(2, attempt);
+      const delay = Math.round(Math.random() * ceiling);
+      log(
+        `compact attempt ${attempt + 1}/${COMPACT_MAX_RETRIES + 1} failed ` +
+        `(${String((err && err.message) || err).slice(0, 140)}); ` +
+        `retrying in ${delay}ms`,
+      );
+      await sleep(delay);
+    }
+  }
 
-  return result.output;
+  throw lastErr;
 }


### PR DESCRIPTION
## Summary

Today a single transient failure of the Morph Compact API discards the **entire** session summary. `hooks/lib/morph.js`'s `compact()` makes exactly one `client.compact()` call; if it throws, `hooks/pre-compact.js` catches it and caches an empty summary (`{ summary: "", error }`), and `hooks/session-start.js` then injects *"Morph compaction failed … Context was NOT preserved."* So a momentary **HTTP 429 rate-limit burst**, a **5xx**, or a **network blip** wipes the user's prior context for that compaction.

This PR makes `compact()` **retry retryable failures with exponential backoff + full jitter** before giving up. The public function signature is unchanged, so `pre-compact.js` needs no changes — the retry is transparent, and the existing empty-summary-on-final-failure behavior is preserved as the last resort.

## Root cause

- `hooks/lib/morph.js` → `compact()` awaits `client.compact(...)` exactly once, no retry.
- On throw, `hooks/pre-compact.js` writes `{ summary: "", error: e.message }`.
- The SDK (`@morphllm/morphsdk` → `dist/tools/compact/core.cjs`) throws a **plain** ``new Error(`Compact API error ${response.status}: ${text}`)`` — it does **not** attach a numeric `status` property, and the thrown error does not expose the `Retry-After` header. Network/timeout failures throw a status-less Error (`fetch failed`, `ECONNRESET`, `AbortError`, etc.).

Because there's no `status` field, the retry classifier parses the status out of the message string.

## The fix

In `hooks/lib/morph.js`:

1. **`isRetryable(err)`** — parses `Compact API error (\d{3})` from the message and retries on **408 / 425 / 429 / 5xx**; for status-less errors, retries on network/timeout/abort signatures (`fetch failed`, `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `EAI_AGAIN`, `socket hang up`, `aborted`, `AbortError`). Auth/validation 4xx (400/401/403/404) **fail fast** — a retry can never succeed.
2. **Retry loop in `compact()`** — up to `MORPH_COMPACT_MAX_RETRIES` extra attempts, exponential backoff with **full jitter** (`random in [0, base · 2^attempt)`), logging each retry via the existing `state.js` `log()` helper.
3. The successful path returns `result.output` exactly as before.

### New configuration (env vars, with safe defaults)

| Variable | Default | Meaning |
|---|---|---|
| `MORPH_COMPACT_MAX_RETRIES` | `3` | Extra attempts after the first (4 total). Set `0` to restore the old single-attempt behavior. |
| `MORPH_COMPACT_RETRY_BASE_MS` | `1000` | Backoff base; attempt *n* waits a random delay in `[0, 1000·2^n)` ms. |

Worst-case added latency at defaults: ~`1+2+4 = 7s` of backoff ceilings (jittered, so typically less) before falling through to the existing empty-summary path. Compaction already runs with a 60s client timeout, so this stays well within hook budgets.

## Scope & limitations

- This fixes **transient** failures (rate-limit *bursts*, 5xx, network). It does **not** fix a **hard quota / plan-limit 429** (`"Rate limit exceeded. Upgrade to a paid plan."`) — that won't clear within a session no matter how many retries, and correctly falls through after the attempts are exhausted.
- For the hard-limit case, the only way to avoid context loss is a **host-side fallback**: today the plugin's install step adds a `CLAUDE.md` override telling Claude to emit only a sentinel and skip its own summary, so when Morph can't deliver, there's *no* fallback summary at all. Consider softening that override (in the `install` skill / `CLAUDE.md` template) so Claude still produces a brief native summary when Morph is unavailable. That's a separate change from this PR but is the other half of the resilience story — happy to follow up.

## Testing

- No new dependencies (`setTimeout` / `Math.random` only); `log()` already exists in `hooks/lib/state.js`.
- Set `MORPH_COMPACT_MAX_RETRIES=0` to confirm the prior single-attempt behavior is restored.
- With a valid key, forcing a failure (unreachable host, or an exhausted rate limit) shows `[morph-compact] compact attempt k/N failed … retrying in Xms` and a later attempt succeeding.

No version bump included (the repo's `.github/workflows/auto-version.yml` handles versioning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
